### PR TITLE
feat: add AlertDialog component and implement Open Library integration settings page

### DIFF
--- a/apps/web/app/(dashboard)/settings/openlibrary/page.tsx
+++ b/apps/web/app/(dashboard)/settings/openlibrary/page.tsx
@@ -1,0 +1,294 @@
+"use client"
+
+import { useState } from "react"
+import Link from "next/link"
+import { useQuery, useMutation } from "@tanstack/react-query"
+import { queryClient } from "@/lib/query-client"
+import { ChevronLeft, CheckCircle2, XCircle, AlertCircle, LogOut, PlugZap, Eye, EyeOff } from "lucide-react"
+
+import { Button } from "@workspace/ui/components/button"
+import { Input } from "@workspace/ui/components/input"
+import { Label } from "@workspace/ui/components/label"
+import { Skeleton } from "@workspace/ui/components/skeleton"
+import { Separator } from "@workspace/ui/components/separator"
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@workspace/ui/components/alert-dialog"
+import { toast } from "sonner"
+
+export default function OpenLibrarySettingsPage() {
+  const [email, setEmail] = useState("")
+  const [password, setPassword] = useState("")
+  const [replaceDialogOpen, setReplaceDialogOpen] = useState(false)
+  const [conflictUsername, setConflictUsername] = useState("")
+  const [disconnectDialogOpen, setDisconnectDialogOpen] = useState(false)
+  const [showPassword, setShowPassword] = useState(false)
+  const [formError, setFormError] = useState<string | null>(null)
+
+  const statusQuery = useQuery({
+    queryKey: ["admin_ol_status"],
+    queryFn: async () => {
+      const res = await fetch("/admin/api/admin/ol/status")
+      if (!res.ok) {
+        const d = await res.json().catch(() => ({}))
+        throw new Error(
+          res.status === 401 || res.status === 403
+            ? "Unauthorized: please log out and back in."
+            : d.error || "Failed to fetch status"
+        )
+      }
+      return res.json()
+    },
+  })
+
+  const loginMutation = useMutation({
+    mutationFn: async ({ replace = false }: { replace?: boolean }) => {
+      const res = await fetch("/admin/api/admin/ol/login", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ email, password, replace }),
+      })
+      const data = await res.json()
+      if (!res.ok) throw { status: res.status, data }
+      return data
+    },
+    onSuccess: (data) => {
+      toast.success(data.message || "Connected successfully")
+      setEmail("")
+      setPassword("")
+      setFormError(null)
+      queryClient.invalidateQueries({ queryKey: ["admin_ol_status"] })
+    },
+    onError: (error: any) => {
+      if (error.status === 409) {
+        setConflictUsername(error.data.username)
+        setReplaceDialogOpen(true)
+        setFormError(null)
+      } else if (error.status === 429) {
+        setFormError("Too many attempts — please wait a few minutes before trying again.")
+      } else if (error.status === 401) {
+        setFormError("Incorrect email or password. Please check your Open Library or Internet Archive credentials.")
+      } else {
+        setFormError(error.data?.message || "Something went wrong. Please try again.")
+      }
+    },
+  })
+
+  const logoutMutation = useMutation({
+    mutationFn: async () => {
+      const res = await fetch("/admin/api/admin/ol/logout", { method: "POST" })
+      if (!res.ok) throw new Error("Logout failed")
+      return res.json()
+    },
+    onSuccess: (data) => {
+      toast.success(data.message || "Disconnected")
+      queryClient.invalidateQueries({ queryKey: ["admin_ol_status"] })
+    },
+    onError: () => toast.error("Failed to disconnect"),
+  })
+
+  const isConnected = statusQuery.data?.logged_in
+  const connectedUser = statusQuery.data?.username
+
+  return (
+    <div className="max-w-2xl space-y-6">
+
+      {/* Back */}
+      <div>
+        <Link
+          href="/settings"
+          className="inline-flex items-center gap-1 text-sm text-muted-foreground hover:text-foreground transition-colors"
+        >
+          <ChevronLeft className="h-3.5 w-3.5" />
+          Settings
+        </Link>
+      </div>
+
+      {/* Header */}
+      <div className="flex items-start justify-between gap-4">
+        <div>
+          <h1 className="text-2xl font-semibold tracking-tight">OpenLibrary</h1>
+          <p className="text-sm text-muted-foreground mt-1">
+            Authenticate with an OpenLibrary account to enable lending on this Lenny instance.
+          </p>
+        </div>
+
+        {/* Status pill — only visible once we have data */}
+        {!statusQuery.isLoading && !statusQuery.isError && (
+          isConnected ? (
+            <span className="inline-flex items-center gap-1.5 rounded-full border border-green-200 bg-green-50 dark:bg-green-900/20 dark:border-green-800 px-2.5 py-1 text-xs font-medium text-green-700 dark:text-green-400 whitespace-nowrap mt-1 shrink-0">
+              <CheckCircle2 className="h-3 w-3" />
+              Connected
+            </span>
+          ) : (
+            <span className="inline-flex items-center gap-1.5 rounded-full border bg-muted/40 px-2.5 py-1 text-xs font-medium text-muted-foreground whitespace-nowrap mt-1 shrink-0">
+              <XCircle className="h-3 w-3" />
+              Not connected
+            </span>
+          )
+        )}
+      </div>
+
+      <Separator />
+
+      {/* Backend error */}
+      {statusQuery.isError && (
+        <div className="flex items-start gap-3 rounded-lg border border-red-200 bg-red-50 dark:bg-red-950/30 dark:border-red-900/50 px-4 py-3 text-sm">
+          <AlertCircle className="h-4 w-4 text-red-500 mt-0.5 shrink-0" />
+          <div>
+            <p className="font-medium text-red-800 dark:text-red-300">Cannot reach backend</p>
+            <p className="text-red-600 dark:text-red-400 text-xs mt-0.5">
+              {statusQuery.error instanceof Error ? statusQuery.error.message : "Unknown error"}
+            </p>
+          </div>
+        </div>
+      )}
+
+      {/* Connected state */}
+      {isConnected && (
+        <div className="flex items-center justify-between rounded-lg border bg-muted/20 px-4 py-3.5">
+          <div className="flex items-center gap-3">
+            <CheckCircle2 className="h-5 w-5 text-green-600 dark:text-green-400 shrink-0" />
+            <div>
+              <p className="text-sm font-medium">Signed in as <span className="text-muted-foreground font-normal">{connectedUser}</span></p>
+              <p className="text-xs text-muted-foreground mt-0.5">Lending is active on this instance</p>
+            </div>
+          </div>
+          <Button
+            variant="outline"
+            size="sm"
+            className="text-red-600 border-red-200 hover:bg-red-50 hover:border-red-300 dark:border-red-900 dark:hover:bg-red-950/50 shrink-0"
+            onClick={() => setDisconnectDialogOpen(true)}
+            disabled={logoutMutation.isPending}
+          >
+            <LogOut className="h-3.5 w-3.5 mr-1.5" />
+            {logoutMutation.isPending ? "Disconnecting…" : "Disconnect"}
+          </Button>
+        </div>
+      )}
+
+      {/* Login form — only when not connected */}
+      {!statusQuery.isLoading && !isConnected && (
+        <>
+          <section className="space-y-4">
+            <div>
+              <h2 className="text-sm font-medium">Sign in to Open Library Account</h2>
+              <p className="text-xs text-muted-foreground mt-0.5">
+                Use your openlibrary.org credentials.
+              </p>
+            </div>
+
+            <form
+              onSubmit={(e) => { e.preventDefault(); loginMutation.mutate({}) }}
+              className="space-y-4"
+            >
+              <div className="space-y-1.5">
+                <Label htmlFor="ol-email">Email</Label>
+                <Input
+                  id="ol-email"
+                  type="email"
+                  placeholder="you@example.org"
+                  value={email}
+                  onChange={(e) => setEmail(e.target.value)}
+                  required
+                  autoComplete="email"
+                  className="max-w-sm"
+                />
+              </div>
+
+              <div className="space-y-1.5">
+                <Label htmlFor="ol-password">Password</Label>
+                <div className="relative max-w-sm">
+                  <Input
+                    id="ol-password"
+                    type={showPassword ? "text" : "password"}
+                    placeholder="••••••••"
+                    value={password}
+                    onChange={(e) => { setPassword(e.target.value); setFormError(null) }}
+                    required
+                    autoComplete="current-password"
+                    className="pr-10"
+                  />
+                  <button
+                    type="button"
+                    onClick={() => setShowPassword((v) => !v)}
+                    className="absolute inset-y-0 right-0 flex items-center px-3 text-muted-foreground hover:text-foreground transition-colors"
+                    tabIndex={-1}
+                    aria-label={showPassword ? "Hide password" : "Show password"}
+                  >
+                    {showPassword ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
+                  </button>
+                </div>
+              </div>
+
+              {/* Inline error */}
+              {formError && (
+                <div className="flex items-start gap-2.5 rounded-lg border border-red-200 bg-red-50 dark:bg-red-950/30 dark:border-red-900/50 px-3.5 py-3 text-sm max-w-sm">
+                  <AlertCircle className="h-4 w-4 text-red-500 mt-0.5 shrink-0" />
+                  <p className="text-red-700 dark:text-red-300">{formError}</p>
+                </div>
+              )}
+
+              <Button
+                type="submit"
+                disabled={loginMutation.isPending || !!statusQuery.isError}
+                className="gap-2"
+              >
+                <PlugZap className="h-4 w-4" />
+                {loginMutation.isPending ? "Connecting…" : "Connect account"}
+              </Button>
+            </form>
+          </section>
+        </>
+      )}
+
+      {/* Disconnect dialog */}
+      <AlertDialog open={disconnectDialogOpen} onOpenChange={setDisconnectDialogOpen}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Disconnect OpenLibrary?</AlertDialogTitle>
+            <AlertDialogDescription>
+              This removes the OpenLibrary S3 keys from the server. Book lending will stop working until you reconnect with OpenLibrary.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+              onClick={() => { logoutMutation.mutate(); setDisconnectDialogOpen(false) }}
+            >
+              Disconnect
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+
+      {/* Replace conflict dialog */}
+      <AlertDialog open={replaceDialogOpen} onOpenChange={setReplaceDialogOpen}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Already connected</AlertDialogTitle>
+            <AlertDialogDescription>
+              Lenny is already signed in as <strong>{conflictUsername}</strong>. Replace with the new account?
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={() => { loginMutation.mutate({ replace: true }); setReplaceDialogOpen(false) }}
+            >
+              Yes, replace
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </div>
+  )
+}

--- a/apps/web/app/(dashboard)/settings/page.tsx
+++ b/apps/web/app/(dashboard)/settings/page.tsx
@@ -1,0 +1,50 @@
+import Link from "next/link"
+import { ChevronRight, BookOpen, Settings2 } from "lucide-react"
+import { Separator } from "@workspace/ui/components/separator"
+
+const integrations = [
+  {
+    href: "/settings/openlibrary",
+    icon: BookOpen,
+    title: "Sign in with OpenLibrary Account",
+    description: "Connect your OpenLibrary account to enable lending",
+  },
+]
+
+export default function SettingsPage() {
+  return (
+    <div className="max-w-2xl space-y-8">
+      <div>
+        <h1 className="text-2xl font-semibold tracking-tight">Settings</h1>
+        <p className="text-sm text-muted-foreground mt-1">Manage your Lenny instance configuration.</p>
+      </div>
+
+      {/* Integrations */}
+      <section className="space-y-1">
+        <div className="flex items-center gap-2 px-1 mb-3">
+          <Settings2 className="h-3.5 w-3.5 text-muted-foreground" />
+          <span className="text-xs font-medium text-muted-foreground uppercase tracking-widest">Integrations</span>
+        </div>
+
+        <div className="rounded-lg border divide-y overflow-hidden">
+          {integrations.map(({ href, icon: Icon, title, description }) => (
+            <Link
+              key={href}
+              href={href}
+              className="flex items-center gap-4 px-4 py-4 bg-background hover:bg-accent/50 transition-colors group"
+            >
+              <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-md border bg-muted/40">
+                <Icon className="h-4 w-4 text-muted-foreground" />
+              </div>
+              <div className="flex-1 min-w-0">
+                <p className="text-sm font-medium">{title}</p>
+                <p className="text-sm text-muted-foreground truncate">{description}</p>
+              </div>
+              <ChevronRight className="h-4 w-4 text-muted-foreground group-hover:translate-x-0.5 transition-transform shrink-0" />
+            </Link>
+          ))}
+        </div>
+      </section>
+    </div>
+  )
+}

--- a/apps/web/app/api/admin/[...path]/route.ts
+++ b/apps/web/app/api/admin/[...path]/route.ts
@@ -1,0 +1,53 @@
+import { NextResponse } from "next/server"
+import { cookies } from "next/headers"
+
+const internalApiUrl = process.env.LENNY_INTERNAL_API_URL // e.g. http://127.0.0.1:1337/v1/api
+const internalSecret = process.env.ADMIN_INTERNAL_SECRET
+
+async function proxyRequest(request: Request, context: { params: Promise<{ path: string[] }> }) {
+    const { path: pathArray } = await context.params
+    const joinedPath = pathArray.join("/")
+
+    const url = new URL(request.url)
+    const searchParams = url.searchParams.toString()
+    const targetUrl = `${internalApiUrl}/admin/${joinedPath}${searchParams ? `?${searchParams}` : ""}`
+
+    const cookieStore = await cookies()
+    const token = cookieStore.get("admin_token")?.value
+
+    const headers: Record<string, string> = {
+        "Authorization": `Bearer ${token ?? ""}`,
+    }
+    if (internalSecret) {
+        headers["X-Admin-Internal-Secret"] = internalSecret
+    }
+
+    let body: BodyInit | null = null
+    if (request.method !== "GET" && request.method !== "HEAD") {
+        const text = await request.text()
+        if (text) {
+            body = text
+            headers["Content-Type"] = request.headers.get("Content-Type") || "application/json"
+        }
+    }
+
+    const upstream = await fetch(targetUrl, {
+        method: request.method,
+        headers,
+        body,
+    })
+
+    const responseBody = await upstream.text()
+    return new NextResponse(responseBody, {
+        status: upstream.status,
+        headers: {
+            "Content-Type": upstream.headers.get("Content-Type") || "application/json",
+        },
+    })
+}
+
+export const GET = proxyRequest
+export const POST = proxyRequest
+export const DELETE = proxyRequest
+export const PUT = proxyRequest
+export const PATCH = proxyRequest

--- a/apps/web/components/app-sidebar.tsx
+++ b/apps/web/components/app-sidebar.tsx
@@ -49,7 +49,7 @@ const data = {
   navSecondary: [
     {
       title: "Settings",
-      url: "#",
+      url: "/settings",
       icon: IconSettings,
     },
     {

--- a/apps/web/components/nav-secondary.tsx
+++ b/apps/web/components/nav-secondary.tsx
@@ -1,6 +1,7 @@
 "use client"
 
 import * as React from "react"
+import Link from "next/link"
 import { type Icon } from "@tabler/icons-react"
 
 import {
@@ -28,10 +29,10 @@ export function NavSecondary({
           {items.map((item) => (
             <SidebarMenuItem key={item.title}>
               <SidebarMenuButton asChild>
-                <a href={item.url}>
+                <Link href={item.url}>
                   <item.icon />
                   <span>{item.title}</span>
-                </a>
+                </Link>
               </SidebarMenuButton>
             </SidebarMenuItem>
           ))}

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -20,7 +20,8 @@
     "next": "^16.2.2",
     "next-themes": "^0.4.6",
     "react": "^19.2.4",
-    "react-dom": "^19.2.4"
+    "react-dom": "^19.2.4",
+    "sonner": "^2.0.7"
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4.2.2",

--- a/packages/ui/src/components/alert-dialog.tsx
+++ b/packages/ui/src/components/alert-dialog.tsx
@@ -1,0 +1,196 @@
+"use client"
+
+import * as React from "react"
+import { AlertDialog as AlertDialogPrimitive } from "radix-ui"
+
+import { cn } from "@workspace/ui/lib/utils"
+import { Button } from "@workspace/ui/components/button"
+
+function AlertDialog({
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Root>) {
+  return <AlertDialogPrimitive.Root data-slot="alert-dialog" {...props} />
+}
+
+function AlertDialogTrigger({
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Trigger>) {
+  return (
+    <AlertDialogPrimitive.Trigger data-slot="alert-dialog-trigger" {...props} />
+  )
+}
+
+function AlertDialogPortal({
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Portal>) {
+  return (
+    <AlertDialogPrimitive.Portal data-slot="alert-dialog-portal" {...props} />
+  )
+}
+
+function AlertDialogOverlay({
+  className,
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Overlay>) {
+  return (
+    <AlertDialogPrimitive.Overlay
+      data-slot="alert-dialog-overlay"
+      className={cn(
+        "fixed inset-0 z-50 bg-black/50 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:animate-in data-[state=open]:fade-in-0",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function AlertDialogContent({
+  className,
+  size = "default",
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Content> & {
+  size?: "default" | "sm"
+}) {
+  return (
+    <AlertDialogPortal>
+      <AlertDialogOverlay />
+      <AlertDialogPrimitive.Content
+        data-slot="alert-dialog-content"
+        data-size={size}
+        className={cn(
+          "group/alert-dialog-content fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border bg-background p-6 shadow-lg duration-200 data-[size=sm]:max-w-xs data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95 data-[size=default]:sm:max-w-lg",
+          className
+        )}
+        {...props}
+      />
+    </AlertDialogPortal>
+  )
+}
+
+function AlertDialogHeader({
+  className,
+  ...props
+}: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="alert-dialog-header"
+      className={cn(
+        "grid grid-rows-[auto_1fr] place-items-center gap-1.5 text-center has-data-[slot=alert-dialog-media]:grid-rows-[auto_auto_1fr] has-data-[slot=alert-dialog-media]:gap-x-6 sm:group-data-[size=default]/alert-dialog-content:place-items-start sm:group-data-[size=default]/alert-dialog-content:text-left sm:group-data-[size=default]/alert-dialog-content:has-data-[slot=alert-dialog-media]:grid-rows-[auto_1fr]",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function AlertDialogFooter({
+  className,
+  ...props
+}: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="alert-dialog-footer"
+      className={cn(
+        "flex flex-col-reverse gap-2 group-data-[size=sm]/alert-dialog-content:grid group-data-[size=sm]/alert-dialog-content:grid-cols-2 sm:flex-row sm:justify-end",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function AlertDialogTitle({
+  className,
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Title>) {
+  return (
+    <AlertDialogPrimitive.Title
+      data-slot="alert-dialog-title"
+      className={cn(
+        "text-lg font-semibold sm:group-data-[size=default]/alert-dialog-content:group-has-data-[slot=alert-dialog-media]/alert-dialog-content:col-start-2",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function AlertDialogDescription({
+  className,
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Description>) {
+  return (
+    <AlertDialogPrimitive.Description
+      data-slot="alert-dialog-description"
+      className={cn("text-sm text-muted-foreground", className)}
+      {...props}
+    />
+  )
+}
+
+function AlertDialogMedia({
+  className,
+  ...props
+}: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="alert-dialog-media"
+      className={cn(
+        "mb-2 inline-flex size-16 items-center justify-center rounded-md bg-muted sm:group-data-[size=default]/alert-dialog-content:row-span-2 *:[svg:not([class*='size-'])]:size-8",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function AlertDialogAction({
+  className,
+  variant = "default",
+  size = "default",
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Action> &
+  Pick<React.ComponentProps<typeof Button>, "variant" | "size">) {
+  return (
+    <Button variant={variant} size={size} asChild>
+      <AlertDialogPrimitive.Action
+        data-slot="alert-dialog-action"
+        className={cn(className)}
+        {...props}
+      />
+    </Button>
+  )
+}
+
+function AlertDialogCancel({
+  className,
+  variant = "outline",
+  size = "default",
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Cancel> &
+  Pick<React.ComponentProps<typeof Button>, "variant" | "size">) {
+  return (
+    <Button variant={variant} size={size} asChild>
+      <AlertDialogPrimitive.Cancel
+        data-slot="alert-dialog-cancel"
+        className={cn(className)}
+        {...props}
+      />
+    </Button>
+  )
+}
+
+export {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogMedia,
+  AlertDialogOverlay,
+  AlertDialogPortal,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -102,6 +102,9 @@ importers:
       react-dom:
         specifier: ^19.2.4
         version: 19.2.4(react@19.2.4)
+      sonner:
+        specifier: ^2.0.7
+        version: 2.0.7(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
     devDependencies:
       '@tailwindcss/postcss':
         specifier: ^4.2.2


### PR DESCRIPTION
This pull request introduces a new OpenLibrary integration to the dashboard, allowing users to connect and manage their OpenLibrary account for lending functionality. It adds a full OpenLibrary settings page with authentication UI, backend proxying for admin API routes, and supporting UI components. The sidebar and navigation are updated to link to the new settings pages. Additionally, a reusable `AlertDialog` component is added to the UI library, and the `sonner` package is introduced for toast notifications.

**OpenLibrary Integration & UI:**
- Added a full-featured OpenLibrary settings page (`openlibrary/page.tsx`) with login, logout, account conflict handling, and real-time status display, using React Query and toast notifications.
- Updated the main settings page to include an "Integrations" section with a link to OpenLibrary.
- Updated the sidebar navigation to link to `/settings` instead of a placeholder.
- Updated the secondary navigation to use `next/link` for client-side routing. [[1]](diffhunk://#diff-4923ad08d03c6fdad76d0da0850fc218390c622a2854a7aaf1731798ac52bcdcR4) [[2]](diffhunk://#diff-4923ad08d03c6fdad76d0da0850fc218390c622a2854a7aaf1731798ac52bcdcL31-R35)

**Backend Integration:**
- Added a proxy API route (`api/admin/[...path]/route.ts`) that forwards admin requests to the internal API, handling authentication and secrets. ([apps/web/app/api/admin/[...path]/route.tsR1-R53](diffhunk://#diff-20bc781ae052c19ed38d90c8c26a014018bfb03ec1ca336ef002ae3f96b3bc3bR1-R53))

**UI Components:**
- Introduced a new, reusable `AlertDialog` component to the UI library for consistent confirmation dialogs.

**Dependencies:**
- Added the `sonner` package for toast notifications to `package.json` and updated the lockfile. [[1]](diffhunk://#diff-14b60f636e1a2b0061da57aaf231cb1ed15a5dc0c592425ed82e58fec95d42d8L23-R24) [[2]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR105-R107)