### PR TITLE
fix: update OLStatusSchema to use nullish instead of optional for user fields

### DIFF
--- a/apps/web/types/api.ts
+++ b/apps/web/types/api.ts
@@ -41,11 +41,11 @@ export class ApiError extends Error {
 
 export const OLStatusSchema = z.object({
   logged_in: z.boolean(),
-  username: z.string().optional(),
-  email: z.string().optional(),
-  s3_key_status: z.string().optional(),
-  last_auth: z.string().optional(),
-  lending_mode: z.string().optional()
+  username: z.string().nullish(),
+  email: z.string().nullish(),
+  s3_key_status: z.string().nullish(),
+  last_auth: z.string().nullish(),
+  lending_mode: z.string().nullish()
 })
 export type OLStatus = z.infer<typeof OLStatusSchema>
 


### PR DESCRIPTION
This pull request makes a small update to the `OLStatusSchema` definition in `api.ts` to improve type safety and consistency. The change replaces `.optional()` with `.nullish()` for several fields, ensuring they can be either `undefined` or `null` as appropriate.

- Schema update:
  * [`apps/web/types/api.ts`](diffhunk://#diff-93b39146c5d4214d5f611d1f872cff08aaf5aaf21ea5d31c181177d0b876aac3L44-R48): Changed the `username`, `email`, `s3_key_status`, `last_auth`, and `lending_mode` fields in `OLStatusSchema` from `.optional()` to `.nullish()` for more accurate handling of missing or null values.